### PR TITLE
Added alt_text to the dictionary returned by get_tweet() and called c…

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -24,7 +24,15 @@ tweet = get_tweet()
 
 images = [tweet["deaths_map_path"], tweet["vax_map_path"]]
 media_ids = [api.media_upload(i).media_id_string for i in images]
+alt_text = tweet["alt_text"]
+
+for id in media_ids:
+    api.create_media_metadata(
+        media_id=id,
+        alt_text=alt_text
+    )
+
 api.update_status(
-    status=tweet["tweet_text"], 
+    status=tweet["tweet_text"],
     media_ids=media_ids
 )

--- a/chivaxbot.py
+++ b/chivaxbot.py
@@ -6,7 +6,7 @@ import pytz
 
 from cairosvg import svg2png
 from datetime import date, datetime, timedelta
-import numpy as np 
+import numpy as np
 
 vax_url = "https://data.cityofchicago.org/api/views/553k-3xzc/rows.json?accessType=DOWNLOAD"
 deaths_url= "https://data.cityofchicago.org/api/views/yhhz-zm2v/rows.json?accessType=DOWNLOAD"
@@ -63,10 +63,20 @@ def get_tweet():
         vaccinations=f'{vax_sum:,}',
         deaths=f'{deaths_sum:,}',
     )
+
+    alt_text = '''
+    Two maps of Chicago, side by side. The map on the left shows COVID-19 deaths
+    per capita by ZIP code. The map on the right shows completed COVID-19
+    vaccination per capita by ZIP code. The maps reveal a disconnect between
+    where residents are getting vaccinated and where COVID-19 deaths are
+    concentrated.
+    '''
+
     return {
         "tweet_text": tweet_text,
         "deaths_map_path": deaths_output_path,
         "vax_map_path": vax_output_path,
+        "alt_text": alt_text
     }
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 requests==2.22.0
-tweepy==3.8.0
+tweepy==3.10.0
 flask==1.1.1
 cairosvg==2.5.1
 pytz==2020.5


### PR DESCRIPTION
I added the alt text we discussed on Slack to `chivaxbot.py` and updated `bot.py` to include a call to the `create_media_metadata` [API endpoint](https://docs.tweepy.org/en/latest/api.html#media-methods), but I think the last step will be testing this once we've upgraded to at least the 3.9.0 version of `tweepy`. 

The alt text should be associated with both map images. I'm not sure if there's a better way of testing besides running the bot locally then checking the tweet in a browser using the Inspector to see if the alt text shows up (the default is "Image").