### PR TITLE
Add check and logging for unexpected zips

### DIFF
--- a/chivaxbot.py
+++ b/chivaxbot.py
@@ -28,6 +28,68 @@ deaths_output_path = os.path.join(os.getcwd(), "exports", "deaths-{}.png".format
     now.strftime("%Y-%m-%d-%H%M")
 ))
 
+chicago_zips = [
+    "60638",
+    "60601",
+    "60606",
+    "60611",
+    "60666",
+    "60645",
+    "60625",
+    "60640",
+    "60626",
+    "60657",
+    "60615",
+    "60621",
+    "60651",
+    "60707",
+    "60631",
+    "60602",
+    "60607",
+    "60630",
+    "60641",
+    "60622",
+    "60636",
+    "60610",
+    "60659",
+    "60614",
+    "60644",
+    "60603",
+    "60634",
+    "60637",
+    "60649",
+    "60618",
+    "60623",
+    "60647",
+    "60629",
+    "60613",
+    "60660",
+    "60654",
+    "60608",
+    "60642",
+    "60604",
+    "60653",
+    "60619",
+    "60655",
+    "60617",
+    "60633",
+    "60612",
+    "60646",
+    "60643",
+    "60628",
+    "60661",
+    "60624",
+    "60609",
+    "60827",
+    "60639",
+    "60632",
+    "60656",
+    "60620",
+    "60605",
+    "60652",
+    "60616"
+]
+
 def get_tweet():
     vax_res = requests.get(vax_url)
     vax_res_json = json.loads(vax_res.text)
@@ -90,7 +152,7 @@ def get_tweet():
 
 def get_colors_dict(values_dict, colorscale, data_type):
     colors_dict = {}
-    arr = list(values_dict.values())
+    arr = list([value for name, value in values_dict.items() if name in chicago_zips])
 
     colors_dict["key_color1"] = colorscale[0]
     colors_dict["key_color2"] = colorscale[1]
@@ -120,23 +182,26 @@ def get_colors_dict(values_dict, colorscale, data_type):
         raise Exception("Unexpected key passed to function. Choose 'vax' or 'deaths'")
 
     for name, value in values_dict.items():
-        # prepend "zip" to make these names less confusing
-        # when they appear in the SVG
-        svg_name = "zip{}".format(name)
+        if name in chicago_zips:
+            # prepend "zip" to make these names less confusing
+            # when they appear in the SVG
+            svg_name = "zip{}".format(name)
 
-        # divide results into 5 even percentiles
-        if (value < key_label1_raw):
-            colors_dict[svg_name] = colors_dict["key_color1"]
-        elif (value < key_label2_raw):
-            colors_dict[svg_name] = colors_dict["key_color2"]
-        elif (value < key_label3_raw):
-            colors_dict[svg_name] = colors_dict["key_color3"]
-        elif (value < key_label4_raw):
-            colors_dict[svg_name] = colors_dict["key_color4"]
-        elif (value <= key_label5_raw):
-            colors_dict[svg_name] = colors_dict["key_color5"]
-        else:
-            colors_dict[svg_name] = "white"
+            # divide results into 5 even percentiles
+            if (value < key_label1_raw):
+                colors_dict[svg_name] = colors_dict["key_color1"]
+            elif (value < key_label2_raw):
+                colors_dict[svg_name] = colors_dict["key_color2"]
+            elif (value < key_label3_raw):
+                colors_dict[svg_name] = colors_dict["key_color3"]
+            elif (value < key_label4_raw):
+                colors_dict[svg_name] = colors_dict["key_color4"]
+            elif (value <= key_label5_raw):
+                colors_dict[svg_name] = colors_dict["key_color5"]
+            else:
+                colors_dict[svg_name] = "white"
+        else: 
+            print("Omitting zip not in Chicago: {}".format(name))
 
     return colors_dict
 

--- a/chivaxbot.py
+++ b/chivaxbot.py
@@ -155,7 +155,7 @@ def get_colors_dict(values_dict, colorscale, data_type):
     colors_dict = {}
     arr = [value for name, value in values_dict.items() if name in chicago_zips]
 
-    # alert us if there are unexpected geo values
+    # alert us if there are unexpected zip values
     bad_zips_arr = [name for name, value in values_dict.items() if name not in chicago_zips and name != "Unknown"]
     if len(bad_zips_arr) > 0:
         logging.error("Unexpected zip values for {data_type} data: {bad_zips}".format(


### PR DESCRIPTION
This PR adds two checks in case any unexpected or badly formatted zip code values come back from the city data:
1. When calculating the percentile cutoffs, make sure we're only using Chicago zips
2. If unexpected zips are returned, trigger a Sentry log that will send me an email so I can check it out

This shouldn't change anything about the current map, but will help make sure we get a heads up about future data issues that could have otherwise slipped by.