### PR TITLE
Add lower bound to key

### DIFF
--- a/chivaxbot.py
+++ b/chivaxbot.py
@@ -162,13 +162,14 @@ def get_colors_dict(values_dict, colorscale, data_type):
             data_type=data_type,
             bad_zips=", ".join(bad_zips_arr)),
         )
-
+        
     colors_dict["key_color1"] = colorscale[0]
     colors_dict["key_color2"] = colorscale[1]
     colors_dict["key_color3"] = colorscale[2]
     colors_dict["key_color4"] = colorscale[3]
     colors_dict["key_color5"] = colorscale[4]
 
+    key_label0_raw = np.percentile(arr, 0)
     key_label1_raw = np.percentile(arr, 20)
     key_label2_raw = np.percentile(arr, 40)
     key_label3_raw = np.percentile(arr, 60)
@@ -176,12 +177,14 @@ def get_colors_dict(values_dict, colorscale, data_type):
     key_label5_raw = np.percentile(arr, 100)
 
     if data_type == "deaths":
+        colors_dict["key_label0"] = round(key_label0_raw, 1)
         colors_dict["key_label1"] = round(key_label1_raw, 1)
         colors_dict["key_label2"] = round(key_label2_raw, 1)
         colors_dict["key_label3"] = round(key_label3_raw, 1)
         colors_dict["key_label4"] = round(key_label4_raw, 1)
         colors_dict["key_label5"] = round(key_label5_raw, 1)
     elif data_type == "vax":
+        colors_dict["key_label0"] = "{}%".format(round(key_label0_raw * 100, 1))
         colors_dict["key_label1"] = "{}%".format(round(key_label1_raw * 100, 1))
         colors_dict["key_label2"] = "{}%".format(round(key_label2_raw * 100, 1))
         colors_dict["key_label3"] = "{}%".format(round(key_label3_raw * 100, 1))

--- a/data/zipcodes-deaths.svg
+++ b/data/zipcodes-deaths.svg
@@ -4816,7 +4816,7 @@
 	<text transform="matrix(1 0 0 1 98.701 382.10791)" class="st1 st2">Deaths per 100,000 people</text>
 	<g>
 		<rect x="131.79401" y="402.56467" class="st0" width="160.5" height="13.5"/>
-		<text transform="matrix(1 0 0 1 131.79401 411.67258)" class="st1 st2">0 to {key_label1}</text>
+		<text transform="matrix(1 0 0 1 131.79401 411.67258)" class="st1 st2">{key_label0} to {key_label1}</text>
 		<rect x="131.79401" y="429.56473" class="st0" width="160.5" height="13.5"/>
 		<text transform="matrix(1 0 0 1 131.79401 438.67264)" class="st1 st2">{key_label1} to {key_label2}</text>
 		<rect x="131.79401" y="456.56479" class="st0" width="160.5" height="13.5"/>

--- a/data/zipcodes-vax.svg
+++ b/data/zipcodes-vax.svg
@@ -4960,7 +4960,7 @@
 	</g>
 	<g>
 		<rect x="131.79401" y="363.56467" class="st0" width="160.5" height="13.5"/>
-		<text transform="matrix(1 0 0 1 131.79401 372.67258)" class="st1 st2">0 to {key_label1}</text>
+		<text transform="matrix(1 0 0 1 131.79401 372.67258)" class="st1 st2">{key_label0} to {key_label1}</text>
 		<rect x="131.79401" y="390.56473" class="st0" width="160.5" height="13.5"/>
 		<text transform="matrix(1 0 0 1 131.79401 399.67264)" class="st1 st2">{key_label1} to {key_label2}</text>
 		<rect x="131.79401" y="417.56479" class="st0" width="160.5" height="13.5"/>


### PR DESCRIPTION
Closes #23. The lower bound of both vax and death rates is 0, so no change for now but will go up in the future, if all does well! New images:

![deaths-2021-01-30-1229](https://user-images.githubusercontent.com/1094243/106364943-e7c7b080-62f7-11eb-943f-3e696c56a783.png)
![vax-2021-01-30-1229](https://user-images.githubusercontent.com/1094243/106364944-e8604700-62f7-11eb-8e9d-a4c8e2e26e75.png)
