### PR TITLE
Column change bug fix

### DIFF
--- a/chivaxbot.py
+++ b/chivaxbot.py
@@ -41,7 +41,7 @@ chicago_zips = [
     "60601",
     "60606",
     "60611",
-    "60666",
+    # "60666",
     "60645",
     "60625",
     "60640",
@@ -117,7 +117,7 @@ def get_tweet():
         if max_date == datetime.strptime(row[9], '%Y-%m-%dT00:00:00'):
             vax_perc[row[8]] = float(row[17])
             vax_sum += int(row[16])
-            population_sum += int(row[18])
+            population_sum += int(row[27])
 
     deaths_perc = {}
     deaths_sum = 0


### PR DESCRIPTION
A couple days ago the city added new columns to our [source sheet](https://data.cityofchicago.org/Health-Human-Services/COVID-19-Vaccine-Doses-by-ZIP-Code-Series-Complete/8u6c-48j3) adding vax number breakdowns by age. This is ripe for other analysis, but broke our population total calculation! This resets that index to the correct value. 

I've also removed the 60666 zip code from our calculations because it has a listed population of 0 and was throwing off our lower bound of zips vaccinated. Are you ok with making that change now, @crunes?

> As of June 11, 2021, Chicago is reporting 1,233,535 people fully vaccinated: 44.6% of the population.
> 
> Who is dying:           Who is vaccinated:

![deaths-2021-06-11-1600](https://user-images.githubusercontent.com/1094243/121749234-f016d000-cacf-11eb-8e19-a4465a5f4a20.png)
![vax-2021-06-11-1600](https://user-images.githubusercontent.com/1094243/121749240-f442ed80-cacf-11eb-8a4c-025c7cdfdd63.png)

